### PR TITLE
[Refactor] useRef 를 사용해 reactStrictMode 환경에서도 useEffect 중복 호출 방지

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  reactStrictMode: false,
+  // reactStrictMode: false,
 };
 
 export default nextConfig;

--- a/src/features/auth/hooks/useKakaoLogin.ts
+++ b/src/features/auth/hooks/useKakaoLogin.ts
@@ -1,11 +1,22 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { requestKakaoLogin } from '../model/requestKakaoLogin';
 
-export const useKakaoLogin = () => {
+interface KakaoLoginResponse {
+  accessToken: string;
+}
+
+export const useKakaoLogin = (
+  options: UseMutationOptions<
+    KakaoLoginResponse, // 성공 타입
+    unknown, // 에러 타입
+    string // 변수 타입
+  >,
+) => {
   return useMutation({
     mutationKey: ['kakaoLogin'],
     mutationFn: (code: string) => requestKakaoLogin(code),
+    ...options,
   });
 };


### PR DESCRIPTION
## 🚩 연관 이슈

closed #11 

<br>

## 📝 작업 내용

- useRef 를 사용하여 `reactStrictMode = true` 설정에서도 useEffect 내부의 카카오 소셜 로그인 api 호출을 '단 한번' 만 하도록 보장
