### PR TITLE
[FEAT] 전반적인 메인 페이지 UI 작업 및 로그아웃 기능 추가

### DIFF
--- a/app/(afterLogin)/main/page.tsx
+++ b/app/(afterLogin)/main/page.tsx
@@ -1,9 +1,46 @@
+import { AITutorChat } from '@/src/features/main/ui/AITutorChat';
+import { LearningAnalytics } from '@/src/features/main/ui/LearningAnalytics';
+import { ProblemRecommendation } from '@/src/features/main/ui/ProblemRecommendation';
+import { UserDashboard } from '@/src/features/main/ui/UserDashboard';
+
+const userData = {
+  userName: 'OOO',
+  solvedTodayCount: 5,
+  totalSolvedCount: 120,
+  currentStreak: 7,
+  learningProgress: 65,
+};
+
 export default function AfterLoginHome() {
   return (
-    <>
-      <div className='mx-auto flex min-h-screen max-w-7xl pt-8'>
-        AfterLogin HomePage
-      </div>
-    </>
+    <div className='min-h-screen bg-gray-50 dark:bg-[var(--background)]'>
+      <main className='mx-auto max-w-7xl space-y-8 px-4 py-8'>
+        {/* 상단: 유저 대시보드 */}
+        <div>
+          <UserDashboard
+            userName={userData.userName}
+            solvedTodayCount={userData.solvedTodayCount}
+            totalSolvedCount={userData.totalSolvedCount}
+            currentStreak={userData.currentStreak}
+            learningProgress={userData.learningProgress}
+          />
+        </div>
+
+        {/* 중앙: AI 튜터 챗(좌) + 학습 분석(우) */}
+        <div className='grid min-h-[420px] grid-cols-1 gap-6 md:grid-cols-3'>
+          <div className='md:col-span-2'>
+            <AITutorChat />
+          </div>
+          <div>
+            <LearningAnalytics />
+          </div>
+        </div>
+
+        {/* 하단: 추천 문제 */}
+        <div>
+          <ProblemRecommendation />
+        </div>
+      </main>
+    </div>
   );
 }

--- a/app/(beforeLogin)/oauth/kakao/page.tsx
+++ b/app/(beforeLogin)/oauth/kakao/page.tsx
@@ -4,6 +4,7 @@ import { useKakaoLogin } from '@/src/features/auth/hooks/useKakaoLogin';
 import { Loader2 } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
 
 export default function KakaoRedirectPage() {
   const router = useRouter();
@@ -13,12 +14,12 @@ export default function KakaoRedirectPage() {
 
   const { mutate: kakaoLogin } = useKakaoLogin({
     onSuccess: (data) => {
-      alert('카카오 로그인 성공!');
+      toast.success('카카오 로그인 성공! 환영합니다.');
       document.cookie = `accessToken=${data.accessToken}; path=/; max-age=3600;`;
       router.replace('/main');
     },
     onError: (error) => {
-      alert('카카오 소셜 로그인에 실패했습니다.');
+      toast.error('카카오 로그인에 실패하였습니다.');
       console.error('카카오 로그인 실패:', error);
       router.replace('/');
     },
@@ -26,11 +27,11 @@ export default function KakaoRedirectPage() {
 
   useEffect(() => {
     if (!code) {
-      alert('카카오로부터 제공된 인가 코드가 없습니다.');
+      toast.error('카카오로부터 인가 코드가 없습니다.');
       router.replace('/');
       return;
     }
-  
+
     if (!hasCalled.current) {
       hasCalled.current = true;
       kakaoLogin(code);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import QueryProvider from '@/src/shared/provider/QueryProvider';
 import ThemeProvider from '@/src/shared/provider/ThemeProvider';
+import SonnerToaster from '@/src/shared/ui/sonner-toaster';
 import type { Metadata } from 'next';
 import './globals.css';
 
@@ -13,7 +14,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang='ko'>
       <body className={`antialiased`}>
         <ThemeProvider>
-          <QueryProvider>{children}</QueryProvider>
+          <QueryProvider>
+            {children}
+            <SonnerToaster />
+          </QueryProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "recharts": "^2.15.3",
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.0.2",
     "tw-animate-css": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.3",
     "tailwind-merge": "^3.0.2",
     "tw-animate-css": "^1.2.4",
     "zustand": "^5.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      recharts:
+        specifier: ^2.15.3
+        version: 2.15.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       sonner:
         specifier: ^2.0.3
         version: 2.0.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -105,6 +108,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@babel/runtime@7.27.1':
+    resolution: {integrity: sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==}
+    engines: {node: '>=6.9.0'}
 
   '@emnapi/core@1.3.1':
     resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
@@ -760,6 +767,33 @@ packages:
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
+  '@types/d3-array@3.2.1':
+    resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
@@ -1047,6 +1081,50 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1079,6 +1157,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1100,6 +1181,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1271,8 +1355,15 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.2.2:
+    resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -1422,6 +1513,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1647,6 +1742,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1895,6 +1993,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -1915,6 +2016,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -1925,9 +2032,25 @@ packages:
       '@types/react':
         optional: true
 
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
   react@19.0.0:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.3:
+    resolution: {integrity: sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2109,6 +2232,9 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyglobby@0.2.12:
     resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
     engines: {node: '>=12.0.0'}
@@ -2193,6 +2319,9 @@ packages:
       '@types/react':
         optional: true
 
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2243,6 +2372,8 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/runtime@7.27.1': {}
 
   '@emnapi/core@1.3.1':
     dependencies:
@@ -2812,6 +2943,30 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.1': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.6': {}
 
   '@types/json-schema@7.0.15': {}
@@ -3142,6 +3297,44 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.0: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -3170,6 +3363,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js-light@2.5.1: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -3191,6 +3386,11 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.27.1
+      csstype: 3.1.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3506,7 +3706,11 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.2.2: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -3662,6 +3866,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -3879,6 +4085,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.17.21: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -4068,6 +4276,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@18.3.1: {}
+
   react-remove-scroll-bar@2.3.8(@types/react@19.0.11)(react@19.0.0):
     dependencies:
       react: 19.0.0
@@ -4087,6 +4297,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.11
 
+  react-smooth@4.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      fast-equals: 5.2.2
+      prop-types: 15.8.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-transition-group: 4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+
   react-style-singleton@2.2.3(@types/react@19.0.11)(react@19.0.0):
     dependencies:
       get-nonce: 1.0.1
@@ -4095,7 +4313,33 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.11
 
+  react-transition-group@4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
   react@19.0.0: {}
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -4348,6 +4592,8 @@ snapshots:
 
   tapable@2.2.1: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.12:
     dependencies:
       fdir: 6.4.3(picomatch@4.0.2)
@@ -4444,6 +4690,23 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.11
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.1
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      sonner:
+        specifier: ^2.0.3
+        version: 2.0.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tailwind-merge:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2026,6 +2029,12 @@ packages:
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+
+  sonner@2.0.3:
+    resolution: {integrity: sha512-njQ4Hht92m0sMqqHVDL32V2Oun9W1+PHO9NDv9FHfJjT3JT22IG4Jpo3FPQy+mouRKCXFWO+r67v6MrHX2zeIA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4256,6 +4265,11 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.2
     optional: true
+
+  sonner@2.0.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   source-map-js@1.2.1: {}
 

--- a/src/features/main/ui/AITutorChat.tsx
+++ b/src/features/main/ui/AITutorChat.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { Button } from '@/src/shared/ui/button';
+import { Input } from '@/src/shared/ui/input';
+import { Bot, Image, Send, User, X } from 'lucide-react';
+import { useRef, useState } from 'react';
+
+interface Message {
+  id: string;
+  content: string;
+  sender: 'user' | 'ai';
+  timestamp: Date;
+  imageUrl?: string;
+}
+
+export function AITutorChat() {
+  const [messages, setMessages] = useState<Message[]>([
+    {
+      id: '1',
+      content: '안녕하세요! 공학수학 학습을 도와드리는 AI 튜터입니다. 어떤 도움이 필요하신가요?',
+      sender: 'ai',
+      timestamp: new Date(),
+    },
+  ]);
+  const [input, setInput] = useState('');
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setSelectedImage(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleSend = () => {
+    if (!input.trim() && !selectedImage) return;
+
+    const newMessage: Message = {
+      id: Date.now().toString(),
+      content: input,
+      sender: 'user',
+      timestamp: new Date(),
+      imageUrl: selectedImage || undefined,
+    };
+
+    setMessages((prev) => [...prev, newMessage]);
+    setInput('');
+    setSelectedImage(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+
+    // AI 응답 시뮬레이션
+    setTimeout(() => {
+      const aiResponse: Message = {
+        id: (Date.now() + 1).toString(),
+        content: '죄송합니다. 현재 AI 튜터 기능은 개발 중입니다. 곧 만나요!',
+        sender: 'ai',
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, aiResponse]);
+    }, 1000);
+  };
+
+  return (
+    <div className='rounded-xl border border-dashed bg-white p-6 dark:border-gray-700 dark:bg-[var(--background)]'>
+      <div className='mb-4'>
+        <h3 className='text-lg font-semibold dark:text-white'>AI 튜터</h3>
+        <p className='text-sm text-gray-500 dark:text-gray-400'>공학수학 학습을 도와드립니다</p>
+      </div>
+
+      <div className='mb-4 h-[500px] space-y-4 overflow-y-auto rounded-lg border bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900'>
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            className={`flex items-start gap-2 ${message.sender === 'user' ? 'justify-end' : ''}`}
+          >
+            {message.sender === 'ai' && (
+              <div className='rounded-full bg-blue-100 p-1 dark:bg-blue-900'>
+                <Bot className='h-5 w-5 text-blue-600 dark:text-blue-400' />
+              </div>
+            )}
+            <div
+              className={`max-w-[80%] rounded-lg p-3 ${
+                message.sender === 'user'
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-white dark:bg-gray-800 dark:text-white'
+              }`}
+            >
+              <p className='text-sm'>{message.content}</p>
+              {message.imageUrl && (
+                <img
+                  src={message.imageUrl}
+                  alt='Uploaded content'
+                  className='mt-2 max-h-48 rounded-lg object-contain'
+                />
+              )}
+            </div>
+            {message.sender === 'user' && (
+              <div className='rounded-full bg-gray-100 p-1 dark:bg-gray-700'>
+                <User className='h-5 w-5 text-gray-600 dark:text-gray-400' />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {selectedImage && (
+        <div className='relative mb-4 flex justify-start'>
+          <div className='flex max-w-xs flex-col items-center rounded-xl border border-gray-300 bg-white p-2 shadow-lg dark:border-gray-600 dark:bg-gray-800'>
+            <div className='relative flex w-full justify-center'>
+              <img
+                src={selectedImage}
+                alt='Selected'
+                className='mx-auto max-h-40 w-auto rounded-lg object-contain'
+              />
+              <button
+                onClick={() => setSelectedImage(null)}
+                className='absolute top-2 right-2 rounded-full bg-black/60 p-1 text-white transition-colors hover:bg-black/80'
+                style={{ zIndex: 10 }}
+                aria-label='이미지 삭제'
+              >
+                <X className='h-4 w-4' />
+              </button>
+            </div>
+            <span className='mt-2 text-xs text-gray-500 dark:text-gray-400'>첨부된 이미지</span>
+          </div>
+        </div>
+      )}
+
+      <div className='flex gap-2'>
+        <input
+          type='file'
+          accept='image/*'
+          onChange={handleImageSelect}
+          ref={fileInputRef}
+          className='hidden'
+        />
+        <Button
+          variant='outline'
+          onClick={() => fileInputRef.current?.click()}
+          className='dark:border-gray-600 dark:text-white'
+        >
+          <Image className='h-4 w-4' />
+        </Button>
+        <Input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder='질문을 입력하세요...'
+          onKeyPress={(e) => e.key === 'Enter' && handleSend()}
+          className='flex-1 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400'
+        />
+        <Button onClick={handleSend} className='dark:bg-blue-600 dark:hover:bg-blue-700'>
+          <Send className='h-4 w-4' />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/main/ui/LearningAnalytics.tsx
+++ b/src/features/main/ui/LearningAnalytics.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+const data = [
+  { name: '1월', value: 65 },
+  { name: '2월', value: 72 },
+  { name: '3월', value: 80 },
+  { name: '4월', value: 85 },
+  { name: '5월', value: 90 },
+  { name: '6월', value: 88 },
+];
+
+const learningAreas = [
+  { name: '미분방정식', progress: 85 },
+  { name: '라플라스 변환', progress: 70 },
+  { name: '푸리에 변환', progress: 60 },
+  { name: '행렬과 행렬식', progress: 75 },
+];
+
+export function LearningAnalytics() {
+  return (
+    <div className='rounded-xl border border-dashed bg-white p-6 dark:border-gray-700 dark:bg-[var(--background)]'>
+      <h3 className='mb-4 text-lg font-semibold dark:text-white'>학습 분석</h3>
+
+      <div className='mb-6 h-64'>
+        <ResponsiveContainer width='100%' height='100%'>
+          <AreaChart data={data}>
+            <defs>
+              <linearGradient id='colorValue' x1='0' y1='0' x2='0' y2='1'>
+                <stop offset='5%' stopColor='#3b82f6' stopOpacity={0.8} />
+                <stop offset='95%' stopColor='#3b82f6' stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid
+              strokeDasharray='3 3'
+              stroke={document.documentElement.classList.contains('dark') ? '#374151' : '#e5e7eb'}
+            />
+            <XAxis
+              dataKey='name'
+              stroke={document.documentElement.classList.contains('dark') ? '#9ca3af' : '#6b7280'}
+            />
+            <YAxis
+              stroke={document.documentElement.classList.contains('dark') ? '#9ca3af' : '#6b7280'}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: document.documentElement.classList.contains('dark')
+                  ? '#1f2937'
+                  : 'white',
+                border: document.documentElement.classList.contains('dark')
+                  ? '1px solid #374151'
+                  : '1px solid #e5e7eb',
+                borderRadius: '0.5rem',
+                color: document.documentElement.classList.contains('dark') ? '#f3f4f6' : '#1f2937',
+              }}
+            />
+            <Area
+              type='monotone'
+              dataKey='value'
+              stroke='#3b82f6'
+              fillOpacity={1}
+              fill='url(#colorValue)'
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className='space-y-4'>
+        {learningAreas.map((area) => (
+          <div key={area.name}>
+            <div className='mb-1 flex justify-between'>
+              <span className='text-sm font-medium dark:text-white'>{area.name}</span>
+              <span className='text-sm text-gray-500 dark:text-gray-400'>{area.progress}%</span>
+            </div>
+            <div className='h-2.5 w-full rounded-full bg-gray-200 dark:bg-gray-700'>
+              <div
+                className='h-2.5 rounded-full bg-blue-600'
+                style={{ width: `${area.progress}%` }}
+              ></div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/main/ui/ProblemRecommendation.tsx
+++ b/src/features/main/ui/ProblemRecommendation.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { Button } from '@/src/shared/ui/button';
+import { BookOpen, ChevronRight } from 'lucide-react';
+
+interface Problem {
+  id: string;
+  title: string;
+  difficulty: '쉬움' | '보통' | '어려움';
+  category: string;
+  solvedCount: number;
+}
+
+const recommendedProblems: Problem[] = [
+  {
+    id: '1',
+    title: '미분방정식 기초 문제',
+    difficulty: '쉬움',
+    category: '미분방정식',
+    solvedCount: 120,
+  },
+  {
+    id: '2',
+    title: '라플라스 변환 응용',
+    difficulty: '보통',
+    category: '라플라스 변환',
+    solvedCount: 85,
+  },
+  {
+    id: '3',
+    title: '푸리에 급수 심화',
+    difficulty: '어려움',
+    category: '푸리에 급수',
+    solvedCount: 45,
+  },
+];
+
+export function ProblemRecommendation() {
+  return (
+    <div className='rounded-xl border border-dashed bg-white p-6 dark:border-gray-700 dark:bg-[var(--background)]'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h3 className='text-lg font-semibold dark:text-white'>추천 문제</h3>
+        <Button variant='ghost' className='gap-1'>
+          더보기
+          <ChevronRight className='h-4 w-4' />
+        </Button>
+      </div>
+
+      <div className='space-y-4'>
+        {recommendedProblems.map((problem) => (
+          <div
+            key={problem.id}
+            className='flex items-center justify-between rounded-lg border p-4 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700'
+          >
+            <div className='flex items-center gap-4'>
+              <div className='rounded-full bg-blue-100 p-2 dark:bg-blue-900'>
+                <BookOpen className='h-5 w-5 text-blue-600 dark:text-blue-400' />
+              </div>
+              <div>
+                <h4 className='font-medium dark:text-white'>{problem.title}</h4>
+                <div className='flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400'>
+                  <span>{problem.category}</span>
+                  <span>•</span>
+                  <span
+                    className={`${
+                      problem.difficulty === '쉬움'
+                        ? 'text-green-600 dark:text-green-400'
+                        : problem.difficulty === '보통'
+                          ? 'text-yellow-600 dark:text-yellow-400'
+                          : 'text-red-600 dark:text-red-400'
+                    }`}
+                  >
+                    {problem.difficulty}
+                  </span>
+                  <span>•</span>
+                  <span>{problem.solvedCount}명 해결</span>
+                </div>
+              </div>
+            </div>
+            <Button variant='outline' size='sm'>
+              풀어보기
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/main/ui/UserDashboard.tsx
+++ b/src/features/main/ui/UserDashboard.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { Button } from '@/src/shared/ui/button';
+import { LogOut, Target, TrendingUp, Trophy } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+interface UserDashboardProps {
+  userName: string;
+  solvedTodayCount: number;
+  totalSolvedCount: number;
+  currentStreak: number;
+  learningProgress: number;
+}
+
+export function UserDashboard({
+  userName,
+  solvedTodayCount,
+  totalSolvedCount,
+  currentStreak,
+  learningProgress,
+}: UserDashboardProps) {
+  const router = useRouter();
+
+  const handleLogout = () => {
+    document.cookie = 'accessToken=; path=/; max-age=0;';
+    toast.success('성공적으로 로그아웃 되었습니다.');
+    router.replace('/');
+  };
+
+  return (
+    <div className='w-full rounded-xl border border-none bg-white p-2 dark:border-gray-700 dark:bg-[var(--background)]'>
+      <div className='flex flex-col gap-4'>
+        <div className='flex items-center justify-between p-4'>
+          <div>
+            <h2 className='text-xl font-semibold dark:text-white'>{userName}님, 안녕하세요!</h2>
+            <p className='text-muted-foreground text-sm dark:text-gray-400'>
+              오늘 푼 문제: <span className='text-primary font-bold'>{solvedTodayCount}개</span>
+            </p>
+          </div>
+          <Button
+            onClick={handleLogout}
+            variant='outline'
+            size='sm'
+            className='gap-1 hover:opacity-80'
+          >
+            <LogOut className='h-4 w-4' />
+            로그아웃
+          </Button>
+        </div>
+
+        <div className='grid grid-cols-1 gap-4 sm:grid-cols-3'>
+          <div className='flex items-center gap-3 rounded-lg bg-white p-4 shadow-sm dark:bg-gray-800'>
+            <Trophy className='h-6 w-6 text-yellow-500' />
+            <div>
+              <p className='text-sm text-gray-500 dark:text-gray-400'>연속 학습</p>
+              <p className='text-lg font-semibold dark:text-white'>{currentStreak}일</p>
+            </div>
+          </div>
+
+          <div className='flex items-center gap-3 rounded-lg bg-white p-4 shadow-sm dark:bg-gray-800'>
+            <Target className='h-6 w-6 text-blue-500' />
+            <div>
+              <p className='text-sm text-gray-500 dark:text-gray-400'>총 푼 문제</p>
+              <p className='text-lg font-semibold dark:text-white'>{totalSolvedCount}개</p>
+            </div>
+          </div>
+
+          <div className='flex items-center gap-3 rounded-lg bg-white p-4 shadow-sm dark:bg-gray-800'>
+            <TrendingUp className='h-6 w-6 text-green-500' />
+            <div>
+              <p className='text-sm text-gray-500 dark:text-gray-400'>학습 진행도</p>
+              <p className='text-lg font-semibold dark:text-white'>{learningProgress}%</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/ui/input.tsx
+++ b/src/shared/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from '@/src/shared/lib/utils';
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot='input'
+      className={cn(
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/src/shared/ui/sonner-toaster.tsx
+++ b/src/shared/ui/sonner-toaster.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { Toaster } from 'sonner';
+
+export default function SonnerToaster() {
+  return <Toaster richColors position='top-center' />;
+}


### PR DESCRIPTION
## 🚩 연관 이슈

closed #13 , #14 , #15 , #16 , #17 


## 📝 작업 내용

- 메인 페이지 전반적인 UI 및 로그아웃 기능 추가

- 로그인 페이지에서 로그인 성공 시 메인 페이지로 넘어올 때 Toast 를 사용하여 알림창 제공

- 로그아웃 시에도 동일

<br>

## ✨ 참고 사항

- 아직은 API 이 구현되지 않아 더미 데이터를 씌운 상태

<br>

## 🏞️ 스크린샷 (OPTION)

<img width="1415" alt="image" src="https://github.com/user-attachments/assets/3fd32a90-b77b-46dd-a53c-8f9d68970306" />

